### PR TITLE
add: interface for `setSTokenRoyaltyForProperty` & `royaltyOf`

### DIFF
--- a/contracts/interfaces/ISTokensManager.sol
+++ b/contracts/interfaces/ISTokensManager.sol
@@ -204,4 +204,14 @@ interface ISTokensManager {
     /// @return The token identifier for the `_index`th NFT assigned to `_owner`,
     ///   (sort order not specified)
     function tokenOfOwnerByIndex(address _owner, uint256 _index) external view returns (uint256);
+
+	/// @dev Sets a resale royalty for the passed Property Tokens's STokens
+	/// @param _property the property for which we register the royalties
+	/// @param _percentage percentage (using 2 decimals - 10000 = 100, 0 = 0)
+	function setSTokenRoyaltyForProperty(address _property, uint256 _percentage) external;
+
+	/// @dev get royalty 
+	/// @param _property property address
+	/// @return Royalty value of a Property's STokens (value in decimals - 10000 = 100, 0 = 0)
+	function royaltyOf(address _property) returns(uint24) external;
 }

--- a/contracts/interfaces/ISTokensManagerV2.sol
+++ b/contracts/interfaces/ISTokensManagerV2.sol
@@ -193,4 +193,14 @@ interface ISTokensManagerV2 is ISTokensManagerStruct {
     /// @return The token identifier for the `_index`th NFT assigned to `_owner`,
     ///   (sort order not specified)
     function tokenOfOwnerByIndex(address _owner, uint256 _index) external view returns (uint256);
+
+	/// @dev Sets a resale royalty for the passed Property Tokens's STokens
+	/// @param _property the property for which we register the royalties
+	/// @param _percentage percentage (using 2 decimals - 10000 = 100, 0 = 0)
+	function setSTokenRoyaltyForProperty(address _property, uint256 _percentage) external;
+
+	/// @dev get royalty 
+	/// @param _property property address
+	/// @return Royalty value of a Property's STokens (value in decimals - 10000 = 100, 0 = 0)
+	function royaltyOf(address _property) returns(uint24) external;
 }


### PR DESCRIPTION
Defined interface for `setSTokenRoyaltyForProperty` & `royaltyOf` 
However, I was unsure about `royaltyOf` since its a public variable 

Please confirm if this the correct way to access a public variable via interface.
<img width="537" alt="Screenshot 2022-11-02 at 2 36 25 PM" src="https://user-images.githubusercontent.com/57281769/199448984-1f4831c5-264a-439b-a268-06b105fd1916.png">

context for `royaltyOf`: https://github.com/dev-protocol/s-tokens/blob/main/contracts/STokensManager.sol#L34