### PR TITLE
docs: fix leftover template-repos-ts-sol README and add missing package.json metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,33 @@
-# template-repos-ts-sol
+# i-s-tokens
 
-Template repository for using TypeScript and Solidity
+Solidity interfaces for the Dev Protocol s-tokens family.
 
-# Usage
+## About
 
-Create a repository using this template; just runs following command.
+This repository publishes the Solidity interface contracts used by Dev Protocol
+s-tokens consumers. It was originally generated from the
+[`template-repos-ts-sol`](https://github.com/dev-protocol/template-repos-ts-sol)
+template and the README title was never updated — this commit aligns the
+README with the repository's actual purpose.
+
+The published interfaces live in `contracts/interfaces/`:
+
+- `ISTokensManager.sol`
+- `ISTokensManagerStruct.sol`
+- `ISTokensManagerV2.sol`
+- `ITokenURIDescriptor.sol`
+
+## Installation
 
 ```bash
 yarn
 ```
+
+## Available Scripts
+
+- `yarn generate` — compile the Solidity contracts
+- `yarn lint` — run Solhint and Prettier
+
+## License
+
+[MPL-2.0](https://github.com/dev-protocol/i-s-tokens/blob/main/LICENSE)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
 		"lint:format": "prettier --write '**/*.{sol,ts,json,md,yml}'",
 		"clean": "rimraf artifacts"
 	},
-	"author": "",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/dev-protocol/i-s-tokens.git"
+	},
+	"author": "Dev Protocol",
 	"license": "MPL-2.0",
 	"files": [
 		"contracts/interfaces"


### PR DESCRIPTION
## Summary

This repository was scaffolded from the `template-repos-ts-sol` template, but the README title was never updated to reflect the actual purpose (s-tokens Solidity interfaces for Dev Protocol). `package.json` `name` was already updated but it was missing the `repository` field and had an empty `author`. This PR finishes the cleanup.

## Changes

- **`package.json`**
  - Added the missing `repository` field pointing to `dev-protocol/i-s-tokens`
  - Replaced `author: ""` with `author: "Dev Protocol"`
  - `license: "MPL-2.0"` was already at the top level and is left untouched

- **`README.md`**
  - Title: `# template-repos-ts-sol` → `# i-s-tokens`
  - Added a short description and the link back to the original template
  - Listed the published interfaces (`ISTokensManager.sol`, `ISTokensManagerStruct.sol`, `ISTokensManagerV2.sol`, `ITokenURIDescriptor.sol`)
  - Listed the available `yarn` scripts

## Why

The README title still shows the template name, which is misleading for anyone landing on the repo. This is a known template-derivation issue affecting several repos in the organization (e.g. `treasury`, `discord-market`); this PR is scoped to `i-s-tokens`.

## Risk

Documentation and metadata only — no code changes, no CI changes, no dependency updates. The compiled `contracts/interfaces/` artifacts are untouched.